### PR TITLE
Add option for streaming command's stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ sudo.exec('echo hello', options,
 );
 ```
 
+If your command is long-running, you can pass the `stream` option to get readable streams instead of a final callback:
+```javascript
+var sudo = require('sudo-prompt');
+var options = {
+  name: 'Electron logger',
+  stream: true
+};
+sudo.exec('dmesg -w', options,
+  function(error, stdout, stderr) {
+    if (error) throw error;
+    // stdout and stderr are readable streams
+    stdout.pipe(process.stdout);
+    stderr.pipe(process.stderr);
+  }
+);
+```
+
 `sudo-prompt` will use `process.title` as `options.name` if `options.name` is not provided. `options.name` must be alphanumeric only (spaces are supported) and at most 70 characters.
 
 Your command should not depend on any current working directory or environment variables in order to execute correctly, and you should take care to use absolute paths and not relative paths.

--- a/test-stream.js
+++ b/test-stream.js
@@ -1,0 +1,49 @@
+var fs = require('fs');
+var sudo = require('./');
+var exec = require('child_process').exec;
+
+function kill(end) {
+  if (process.platform === 'win32') return end();
+  exec('sudo -k', end);
+}
+
+function icns() {
+  if (process.platform !== 'darwin') return undefined;
+  var path = '/Applications/Electron.app/Contents/Resources/Electron.icns';
+  try {
+    fs.statSync(path);
+    return path;
+  } catch (error) {}
+  return undefined;
+}
+
+kill(
+  function() {
+    var options = {
+      icns: icns(),
+      name: 'Electron',
+      stream: true
+    };
+    var command = (process.platform === 'win32') ? 'for /l %x in (1, 1, 100) do echo %x' : 'dmesg -w';
+    var willkill = false;
+    console.log('sudo.exec(' + JSON.stringify(command) + ', ' + JSON.stringify(options) + ')');
+    sudo.exec(command, options,
+      function(error, stdout, stderr) {
+        console.log('error: ' + error);
+        // stdout.pipe(process.stdout);
+        if (!willkill) {
+          willkill = true;
+          setTimeout(function() {
+            kill(
+              function() {
+                if (error) throw error;
+                console.log('OK');
+                process.exit(0);
+              }
+            );
+          }, 1000);
+        }
+      }
+    );
+  }
+);


### PR DESCRIPTION
This PR implements a `stream` boolean option, updates the README with documentation for said option and adds a `test-stream.js` test script.

From the proposed updated README:

*If your command is long-running, you can pass the `stream` option to get readable streams instead of a final callback:*
```javascript
var sudo = require('sudo-prompt');
var options = {
  name: 'Electron logger',
  stream: true
};
sudo.exec('dmesg -w', options,
  function(error, stdout, stderr) {
    if (error) throw error;
    // stdout and stderr are readable streams
    stdout.pipe(process.stdout);
    stderr.pipe(process.stderr);
  }
);
```

This feature is implemented for all OSes but i've only tested it on Linux. Needs a bit more testing, especially on Windows.