### PR TITLE
change code page to utf-8 before executing commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -648,6 +648,8 @@ function WindowsWriteElevateScript(instance, end) {
 function WindowsWriteExecuteScript(instance, end) {
   var script = [];
   script.push('@echo off');
+  // Set code page to UTF-8:
+  script.push('chcp 65001>nul');
   script.push(
     'call "' + instance.pathCommand + '"' +
     ' > "' + instance.pathStdout + '" 2> "' + instance.pathStderr + '"'


### PR DESCRIPTION
Still encounter the issue mentioned in #103 with v9.0.0, fixes by this PR.