### PR TITLE
Fix "Unable to find pkexec or kdesudo" error on NixOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ function Linux(instance, end) {
       }
       var magic = 'SUDOPROMPT\n';
       command.push(
-        '/bin/bash -c "echo ' + EscapeDoubleQuotes(magic.trim()) + '; ' +
+        '/usr/bin/env bash -c "echo ' + EscapeDoubleQuotes(magic.trim()) + '; ' +
         EscapeDoubleQuotes(instance.command) +
         '"'
       );

--- a/index.js
+++ b/index.js
@@ -201,9 +201,7 @@ function LinuxBinary(instance, end) {
   // However, gksudo cannot run multiple commands concurrently.
   var paths = ['/usr/bin/kdesudo', '/usr/bin/pkexec'];
   function test() {
-    if (index === paths.length) {
-      return end(new Error('Unable to find pkexec or kdesudo.'));
-    }
+    if (index === paths.length) return which();
     var path = paths[index++];
     Node.fs.stat(path,
       function(error) {
@@ -214,6 +212,17 @@ function LinuxBinary(instance, end) {
         } else {
           end(undefined, path);
         }
+      }
+    );
+  }
+  function which() {
+    // Operating system paths are not always predictable.
+    // Fallback to a best-effort search for pkexec.
+    Node.child.exec('which pkexec',
+      function(error, stdout, stderr) {
+        if (error) return end(new Error('Unable to find pkexec or kdesudo.'));
+        var path = stdout.toString('utf-8').trim(); // Remove trailing newline.
+        end(undefined, path);
       }
     );
   }


### PR DESCRIPTION
Fixes #77

I reused the commit 0e933b7 that fallbacks to `which` if it cannot find `kdesudo` or `pkexec` in the hardcoded paths.

Fixed "Error: User did not grant permission" (from https://github.com/jorangreef/sudo-prompt/issues/77#issuecomment-445900662) by replacing `/bin/bash` with `/usr/bin/env bash`.

**Additional context**
The above error ("Error: User did not grant permission") is very misleading because the underlying issue is that `/bin/bash` could not be found (the file does not exist on NixOS).

In the future, it would be nice to refactor the error handling in https://github.com/jorangreef/sudo-prompt/blob/master/index.js#L188 so that the error message would be more descriptive.