### PR TITLE
Provide namespace for promisyfing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,20 +6,10 @@ export function exec(cmd: string,
 // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
 namespace exec {
   function __promisify__(command: string): PromiseWithChild<{ stdout: string; stderr: string }>
-  function __promisify__(
-    command: string,
-    options: { encoding: 'buffer' | null } & ExecOptions
-  ): PromiseWithChild<{ stdout: Buffer; stderr: Buffer }>
-  function __promisify__(
-    command: string,
-    options: { encoding: BufferEncoding } & ExecOptions
-  ): PromiseWithChild<{ stdout: string; stderr: string }>
-  function __promisify__(
-    command: string,
-    options: ExecOptions
-  ): PromiseWithChild<{ stdout: string; stderr: string }>
-  function __promisify__(
-    command: string,
-    options?: ({ encoding?: string | null } & ExecOptions) | null
-  ): PromiseWithChild<{ stdout: string | Buffer; stderr: string | Buffer }>
+  function __promisify__<TBuffer = string | Buffer>(
+      command: string,
+      options:
+        | ((error?: Error, stdout?: TBuffer, stderr?: TBuffer) => void)
+        | { name?: string; icns?: string; env?: { [key: string]: string } }
+    ): PromiseWithChild<{ stdout: TBuffer; stderr: TBuffer }>
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,3 +2,24 @@ export function exec(cmd: string,
         options?: ((error?: Error, stdout?: string | Buffer, stderr?: string | Buffer) => void)
                 | { name?: string, icns?: string, env?: { [key: string]: string } },
         callback?: (error?: Error, stdout?: string | Buffer, stderr?: string | Buffer) => void): void;
+
+// NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+namespace exec {
+  function __promisify__(command: string): PromiseWithChild<{ stdout: string; stderr: string }>
+  function __promisify__(
+    command: string,
+    options: { encoding: 'buffer' | null } & ExecOptions
+  ): PromiseWithChild<{ stdout: Buffer; stderr: Buffer }>
+  function __promisify__(
+    command: string,
+    options: { encoding: BufferEncoding } & ExecOptions
+  ): PromiseWithChild<{ stdout: string; stderr: string }>
+  function __promisify__(
+    command: string,
+    options: ExecOptions
+  ): PromiseWithChild<{ stdout: string; stderr: string }>
+  function __promisify__(
+    command: string,
+    options?: ({ encoding?: string | null } & ExecOptions) | null
+  ): PromiseWithChild<{ stdout: string | Buffer; stderr: string | Buffer }>
+}


### PR DESCRIPTION
**`child_process.d.ts`** has next namespace for `util.promisify`:
```ts
// NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
namespace exec {
        function __promisify__(command: string): PromiseWithChild<{ stdout: string, stderr: string }>;
        function __promisify__(command: string, options: { encoding: "buffer" | null } & ExecOptions): PromiseWithChild<{ stdout: Buffer, stderr: Buffer }>;
        function __promisify__(command: string, options: { encoding: BufferEncoding } & ExecOptions): PromiseWithChild<{ stdout: string, stderr: string }>;
        function __promisify__(command: string, options: ExecOptions): PromiseWithChild<{ stdout: string, stderr: string }>;
        function __promisify__(command: string, options?: ({ encoding?: string | null } & ExecOptions) | null): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
    }
```

It allows wrapping error-first contracts in promises.
I've tested it on my application with having module augmentation.

```ts
declare module 'sudo-prompt' {
  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
  namespace exec {
    function __promisify__(command: string): PromiseWithChild<{ stdout: string; stderr: string }>
    function __promisify__(
      command: string,
      options: { encoding: 'buffer' | null } & ExecOptions
    ): PromiseWithChild<{ stdout: Buffer; stderr: Buffer }>
    function __promisify__(
      command: string,
      options: { encoding: BufferEncoding } & ExecOptions
    ): PromiseWithChild<{ stdout: string; stderr: string }>
    function __promisify__(
      command: string,
      options: ExecOptions
    ): PromiseWithChild<{ stdout: string; stderr: string }>
    function __promisify__(
      command: string,
      options?: ({ encoding?: string | null } & ExecOptions) | null
    ): PromiseWithChild<{ stdout: string | Buffer; stderr: string | Buffer }>
  }
}
```

And it works!